### PR TITLE
Fix Ecto repo config in README.md.eex

### DIFF
--- a/README.md.eex
+++ b/README.md.eex
@@ -43,7 +43,7 @@ live_admin "/my_admin" do
 end
 ```
 
-Finally, tell LiveAdmin what Ecto repo to use to run queries in your `runtime.ex`: `config :live_admin, ecto_repo: MyApp.Repo`
+Finally, tell LiveAdmin what Ecto repo to use to run queries in your `config/config.exs`: `config :live_admin, ecto_repo: MyApp.Repo`
 
 That's it, now an admin UI for `MyApp.Schema` will be available at `/my_admin/my_schemas`.
 


### PR DESCRIPTION
The info provided was not correct. That would only work after using `mix release`. With the config set in the `config/config.exs` it is working in all environments.