### PR TITLE
Bug: 'Edit' button is not visible when `:delete_with` is `false`

### DIFF
--- a/lib/live_admin/components/resource/view.ex
+++ b/lib/live_admin/components/resource/view.ex
@@ -54,7 +54,7 @@ defmodule LiveAdmin.Components.Container.View do
           <% end %>
         </dl>
         <div class="form__actions">
-          <%= if @resource.__live_admin_config__(:delete_with) != false do %>
+          <%= if @resource.__live_admin_config__(:update_with) != false do %>
             <.link
               navigate={route_with_params(assigns, segments: [:edit, @record])}
               class="resource__action--btn"


### PR DESCRIPTION
Fixed to show the edit button unless `update_with` is `false`.