### PR TITLE
Fix deprecation warning

### DIFF
--- a/lib/live_admin.ex
+++ b/lib/live_admin.ex
@@ -123,7 +123,7 @@ defmodule LiveAdmin do
       )
 
   def fetch_config(resource, key, config),
-    do: Keyword.get(resource.__live_admin_config__, key) || Keyword.fetch!(config, key)
+    do: Keyword.get(resource.__live_admin_config__(), key) || Keyword.fetch!(config, key)
 
   def primary_key!(resource) do
     [key] = Keyword.fetch!(resource.__live_admin_config__(), :schema).__schema__(:primary_key)


### PR DESCRIPTION
Fixes deprecation warning:

```
using map.field notation (without parentheses) to invoke function LevelWeb.AdminPanel.User.__live_admin_config__() is deprecated, you must add parentheses instead: remote.function()
  (live_admin 0.12.0) lib/live_admin.ex:126: LiveAdmin.fetch_config/3
  (live_admin 0.12.0) lib/live_admin/components/nav.ex:41: anonymous fn/3 in LiveAdmin.Components.Nav.render/1
  (elixir 1.17.2) lib/enum.ex:2531: Enum."-reduce/3-lists^foldl/2-0-"/3
  (live_admin 0.12.0) lib/live_admin/components/nav.ex:38: LiveAdmin.Components.Nav.render/1
  (phoenix_live_view 0.20.17) lib/phoenix_live_view/renderer.ex:79: Phoenix.LiveView.Renderer.to_rendered/2
  (phoenix_live_view 0.20.17) lib/phoenix_live_view/diff.ex:335: Phoenix.LiveView.Diff.component_to_rendered/3
  (phoenix_live_view 0.20.17) lib/phoenix_live_view/diff.ex:753: Phoenix.LiveView.Diff.render_component/8
  (phoenix_live_view 0.20.17) lib/phoenix_live_view/diff.ex:697: Phoenix.LiveView.Diff.zip_components/5
  (phoenix_live_view 0.20.17) lib/phoenix_live_view/diff.ex:680: anonymous fn/4 in Phoenix.LiveView.Diff.render_pending_components/6
  (stdlib 6.0.1) maps.erl:860: :maps.fold_1/4
  (phoenix_live_view 0.20.17) lib/phoenix_live_view/diff.ex:625: Phoenix.LiveView.Diff.render_pending_components/6
  (phoenix_live_view 0.20.17) lib/phoenix_live_view/diff.ex:143: Phoenix.LiveView.Diff.render/3
  (phoenix_live_view 0.20.17) lib/phoenix_live_view/static.ex:249: Phoenix.LiveView.Static.to_rendered_content_tag/4
  (phoenix_live_view 0.20.17) lib/phoenix_live_view/static.ex:132: Phoenix.LiveView.Static.render/3
  (phoenix_live_view 0.20.17) lib/phoenix_live_view/controller.ex:39: Phoenix.LiveView.Controller.live_render/3
  (phoenix 1.7.14) lib/phoenix/router.ex:484: Phoenix.Router.__call__/5
  (level 0.1.0) lib/level_web/endpoint.ex:1: LevelWeb.Endpoint.plug_builder_call/2
```