### PR TITLE
fix: render unique ids for nested embeds in show view

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM hexpm/elixir:1.19.5-erlang-26.2.5-ubuntu-jammy-20251013
 
-RUN apt-get update -y && apt-get install -y build-essential git nodejs npm curl inotify-tools \
+RUN apt-get update -y && apt-get install -y build-essential git curl inotify-tools \
   && apt-get clean && rm -f /var/lib/apt/lists/*_*
 RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
   && apt-get install -y nodejs

--- a/lib/live_admin/components/resource/show.ex
+++ b/lib/live_admin/components/resource/show.ex
@@ -90,8 +90,8 @@ defmodule LiveAdmin.Components.Container.Show do
     """
   end
 
-  attr(:last, :integer, default: 0)
-  attr(:current, :integer, default: 0)
+  attr(:sibling_count, :integer, default: 0)
+  attr(:current_index, :integer, default: 0)
   attr(:id, :string, required: true)
   attr(:record, :map, required: true)
   attr(:resource, :map, required: true)
@@ -116,17 +116,17 @@ defmodule LiveAdmin.Components.Container.Show do
       )
 
     ~H"""
-    <div class="detail-view" id={if @id != "main", do: "#{@id}_#{@current}", else: "main"}>
-      <%= if Enum.any?(@embeds) || @last > 0 do %>
+    <div class="detail-view" id={indexed_id(@id, @current_index)}>
+      <%= if Enum.any?(@embeds) || @sibling_count > 0 do %>
         <div class="tabs">
           <%= if @id == "main" do %>
             <a href="#main" id="main-link"></a>
           <% end %>
           <%= for {field, _, _} <- @embeds, @record |> Map.fetch!(field) |> List.wrap() |> Enum.any? do %>
-            <a href={"##{@id}_#{field}_0"}>{trans(humanize(field))}</a>
+            <a href={"##{indexed_id(@id, @current_index)}_#{field}_0"}>{trans(humanize(field))}</a>
           <% end %>
-          <%= if @last > 0 do %>
-            <%= for n <- 0..@last do %>
+          <%= if @sibling_count > 0 do %>
+            <%= for n <- 0..@sibling_count do %>
               <a href={"##{@id}_#{n}"}>{n}</a>
             <% end %>
           <% end %>
@@ -184,7 +184,7 @@ defmodule LiveAdmin.Components.Container.Show do
                   </a>
                 <% end %>
                 <.expand_modal
-                  id={"#{@id}-#{field}-#{@current}-expand"}
+                  id={"#{indexed_id(@id, @current_index)}-#{field}-expand"}
                   title={@title}
                   field={field}
                   value={Map.fetch!(@record, field)}
@@ -197,12 +197,12 @@ defmodule LiveAdmin.Components.Container.Show do
       <%= for {field, {_, {_, %{related: schema}}}, _} <- @embeds, embed = Map.fetch!(@record, field), list = List.wrap(embed) do %>
         <%= for {record, index} <- Enum.with_index(list) do %>
           <.detail_view
-            id={"#{@id}_#{field}"}
+            id={"#{indexed_id(@id, @current_index)}_#{field}"}
             fields={Enum.map(schema.__schema__(:fields), &{&1, schema.__schema__(:type, &1), []})}
             record={record}
             title={trans(humanize(field))}
-            current={index}
-            last={Enum.count(list) - 1}
+            current_index={index}
+            sibling_count={Enum.count(list) - 1}
             resource={@resource}
             resources={@resources}
             base_path={@base_path}
@@ -218,6 +218,9 @@ defmodule LiveAdmin.Components.Container.Show do
 
   defp renderable?({_, {Ecto.Embedded, _}}), do: false
   defp renderable?(_), do: true
+
+  defp indexed_id("main", _), do: "main"
+  defp indexed_id(id, index), do: "#{id}_#{index}"
 
   defp assoc_resource_key(resource, field, resources, config) do
     schema = LiveAdmin.fetch_config(resource, :schema, config)

--- a/test/live_admin/components/container_test.exs
+++ b/test/live_admin/components/container_test.exs
@@ -266,6 +266,27 @@ defmodule LiveAdmin.Components.ContainerTest do
     end
   end
 
+  describe "view resource with plural embed containing nested plural embed" do
+    setup %{conn: conn} do
+      post =
+        Repo.insert!(%Post{
+          title: "test",
+          previous_versions: [
+            %Version{links: [%Version.Link{url: "https://a.example"}]},
+            %Version{links: [%Version.Link{url: "https://b.example"}]}
+          ]
+        })
+
+      {:ok, view, _} = live(conn, "/live_admin_test_post/#{post.post_id}")
+
+      %{view: view}
+    end
+
+    test "renders unique detail-view id for each parent's nested embed", %{view: view} do
+      assert has_element?(view, "#main_previous_versions_1_links_0")
+    end
+  end
+
   describe "view child resource" do
     setup %{conn: conn} do
       user = Repo.insert!(%User{})

--- a/test/support/resources.ex
+++ b/test/support/resources.ex
@@ -79,6 +79,17 @@ defmodule LiveAdminTest.Post.Version do
     field(:body, :string)
     field(:tags, {:array, :string})
 
+    embeds_many(:links, __MODULE__.Link)
+
     timestamps(updated_at: false)
+  end
+end
+
+defmodule LiveAdminTest.Post.Version.Link do
+  use Ecto.Schema
+
+  @primary_key false
+  embedded_schema do
+    field(:url, :string)
   end
 end


### PR DESCRIPTION
## Summary

- Bug: in the show view, nested `embeds_many` rendered child detail-views with non-unique DOM ids and non-unique tab hrefs. With two parent embeds each containing the same child embed, only one child node was reachable; LiveView raised "Duplicate id found" errors.
- Cause: `detail_view/1` constructed nested ids and tab hrefs from the parent's `@id` only, ignoring the parent's index in its own embed list.
- Fix: extract a small `indexed_id/2` helper and use it for the outer div id, embed tab hrefs, the expand modal id, and the nested `<.detail_view>` id. Renamed `:current` attr to `:current_index` and `:last` attr to `:sibling_count` to reflect intent.

Also drops `nodejs npm` from the first apt step in the Dockerfile — Ubuntu's `npm` now pulls in `libnode-dev`, which collides with NodeSource's nodejs 18 over `/usr/include/node/common.gypi`.

## Test plan

- [x] New describe block in `container_test.exs` reproduces the duplicate-id failure before the fix and passes after
- [x] Full `mix test` suite passes (31 tests)
- [x] `mix format --check-formatted` clean for changed files