### PR TITLE
fix: render sibling tabs at parent level in show view

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -63,6 +63,14 @@ Hooks.Show = {
        tabContent.style.setProperty('display', 'none');
       }
     };
+
+    for (const tabRow of el.querySelectorAll('[data-tab-group]')) {
+      if (urlHash.startsWith(`#${tabRow.dataset.tabGroup}_`)) {
+        tabRow.style.removeProperty('display');
+      } else {
+        tabRow.style.setProperty('display', 'none');
+      }
+    };
   },
   mounted() {
     this.setTab(this.el);

--- a/dev/populator.ex
+++ b/dev/populator.ex
@@ -28,7 +28,13 @@ defmodule Demo.Populator do
             body: Faker.Lorem.paragraphs() |> Enum.join("\n\n"),
             disabled_user: get_user_if(:rand.uniform(2) == 1),
             previous_versions: [
-              %Demo.Posts.Post.Version{body: Faker.Lorem.paragraphs() |> Enum.join("\n\n")}
+              %Demo.Posts.Post.Version{
+                body: Faker.Lorem.paragraphs() |> Enum.join("\n\n"),
+                links:
+                  Enum.map(1..Enum.random(1..3), fn _ ->
+                    %Demo.Posts.Post.Version.Link{url: Faker.Internet.url()}
+                  end)
+              }
             ]
           }
         ]

--- a/dev/post.ex
+++ b/dev/post.ex
@@ -62,6 +62,17 @@ defmodule Demo.Posts.Post.Version do
     field :body, :string
     field :tags, {:array, :string}
 
+    embeds_many :links, __MODULE__.Link
+
     timestamps(updated_at: false)
+  end
+end
+
+defmodule Demo.Posts.Post.Version.Link do
+  use Ecto.Schema
+
+  @primary_key false
+  embedded_schema do
+    field :url, :string
   end
 end

--- a/dist/js/app.js
+++ b/dist/js/app.js
@@ -9008,6 +9008,14 @@ removing illegal node: "${(childNode.outerHTML || childNode.nodeValue).trim()}"
         }
       }
       ;
+      for (const tabRow of el.querySelectorAll("[data-tab-group]")) {
+        if (urlHash.startsWith(`#${tabRow.dataset.tabGroup}_`)) {
+          tabRow.style.removeProperty("display");
+        } else {
+          tabRow.style.setProperty("display", "none");
+        }
+      }
+      ;
     },
     mounted() {
       this.setTab(this.el);

--- a/lib/live_admin/components/resource/show.ex
+++ b/lib/live_admin/components/resource/show.ex
@@ -90,7 +90,6 @@ defmodule LiveAdmin.Components.Container.Show do
     """
   end
 
-  attr(:sibling_count, :integer, default: 0)
   attr(:current_index, :integer, default: 0)
   attr(:id, :string, required: true)
   attr(:record, :map, required: true)
@@ -117,7 +116,7 @@ defmodule LiveAdmin.Components.Container.Show do
 
     ~H"""
     <div class="detail-view" id={indexed_id(@id, @current_index)}>
-      <%= if Enum.any?(@embeds) || @sibling_count > 0 do %>
+      <%= if Enum.any?(@embeds) do %>
         <div class="tabs">
           <%= if @id == "main" do %>
             <a href="#main" id="main-link"></a>
@@ -125,12 +124,16 @@ defmodule LiveAdmin.Components.Container.Show do
           <%= for {field, _, _} <- @embeds, @record |> Map.fetch!(field) |> List.wrap() |> Enum.any? do %>
             <a href={"##{indexed_id(@id, @current_index)}_#{field}_0"}>{trans(humanize(field))}</a>
           <% end %>
-          <%= if @sibling_count > 0 do %>
-            <%= for n <- 0..@sibling_count do %>
-              <a href={"##{@id}_#{n}"}>{n}</a>
-            <% end %>
-          <% end %>
         </div>
+        <%= for {field, {_, {Ecto.Embedded, %{cardinality: :many}}}, _} <- @embeds,
+                list = Map.fetch!(@record, field),
+                Enum.any?(list) do %>
+          <div class="tabs" data-tab-group={"#{indexed_id(@id, @current_index)}_#{field}"}>
+            <%= for {_, n} <- Enum.with_index(list) do %>
+              <a href={"##{indexed_id(@id, @current_index)}_#{field}_#{n}"}>{n}</a>
+            <% end %>
+          </div>
+        <% end %>
       <% end %>
       <div class="card-section">
         <div class="detail-grid">
@@ -202,7 +205,6 @@ defmodule LiveAdmin.Components.Container.Show do
             record={record}
             title={trans(humanize(field))}
             current_index={index}
-            sibling_count={Enum.count(list) - 1}
             resource={@resource}
             resources={@resources}
             base_path={@base_path}

--- a/test/live_admin/components/container_test.exs
+++ b/test/live_admin/components/container_test.exs
@@ -285,6 +285,33 @@ defmodule LiveAdmin.Components.ContainerTest do
     test "renders unique detail-view id for each parent's nested embed", %{view: view} do
       assert has_element?(view, "#main_previous_versions_1_links_0")
     end
+
+    test "renders sibling navigation tab at parent level", %{view: view} do
+      assert has_element?(view, "#main > .tabs a[href=\"#main_previous_versions_1\"]")
+    end
+
+    test "does not render sibling navigation tab inside child detail-view", %{view: view} do
+      refute has_element?(
+               view,
+               "#main_previous_versions_0 > .tabs a[href=\"#main_previous_versions_1\"]"
+             )
+    end
+
+    test "renders numbered sibling tab for plural embed with single item", %{view: view} do
+      assert has_element?(
+               view,
+               "#main_previous_versions_0 > .tabs a[href=\"#main_previous_versions_0_links_0\"]",
+               "0"
+             )
+    end
+
+    test "renders embed-type tab for nested links embed", %{view: view} do
+      assert has_element?(
+               view,
+               "#main_previous_versions_0 > .tabs a[href=\"#main_previous_versions_0_links_0\"]",
+               "Links"
+             )
+    end
   end
 
   describe "view child resource" do


### PR DESCRIPTION
## Summary

- Sibling-section navigation tabs (e.g. \`0\`, \`1\` for an \`embeds_many\` list) and a section's own child embed tabs (e.g. a nested \`FIELDS\` embed) were both rendered inside each child detail-view's \`.tabs\` container. Visually, the child embed tab appeared as a peer of the section selectors instead of nested inside its section.
- This PR moves sibling-section navigation into the parent's iteration loop so each child's \`.tabs\` only contains its own embed tabs. The section selector renders once per embed list, between the parent's card and the child detail-views.

## Test plan

- [x] Two new tests in \`container_test.exs\` assert the sibling navigation tab renders as a child of the parent and not inside a child detail-view; both fail before the change and pass after
- [x] Full \`mix test\` suite passes (33 tests)
- [x] \`mix format --check-formatted\` clean for changed files