### PR TITLE
fix: avoid progress bar oscillation during bulk actions

### DIFF
--- a/lib/live_admin/components/resource/index.ex
+++ b/lib/live_admin/components/resource/index.ex
@@ -393,9 +393,12 @@ defmodule LiveAdmin.Components.Container.Index do
 
     job =
       Task.Supervisor.async_nolink(LiveAdmin.Task.Supervisor, fn ->
-        socket.assigns.selected
-        |> Enum.with_index()
-        |> Enum.each(fn {id, idx} ->
+        selected = socket.assigns.selected
+        total = Enum.count(selected)
+
+        selected
+        |> Enum.with_index(1)
+        |> Enum.reduce_while(:ok, fn {id, idx}, _ ->
           try do
             id
             |> Resource.find(resource, prefix, repo, config)
@@ -405,28 +408,32 @@ defmodule LiveAdmin.Components.Container.Index do
             end
 
             LiveAdmin.PubSub.update_job(session.id, self(),
-              progress: idx / Enum.count(socket.assigns.selected),
+              progress: idx / total,
               label: name
             )
+
+            {:cont, :ok}
           rescue
             error ->
               Logger.error(inspect(error))
-
-              LiveAdmin.PubSub.announce(
-                session.id,
-                :error,
-                trans("%{name} encountered an error and stopped", inter: [name: name])
-              )
-          after
-            LiveAdmin.PubSub.update_job(session.id, self(), progress: 1)
+              {:halt, :error}
           end
         end)
+        |> case do
+          :ok ->
+            LiveAdmin.PubSub.announce(
+              session.id,
+              :info,
+              trans("%{name} complete", inter: [name: name])
+            )
 
-        LiveAdmin.PubSub.announce(
-          session.id,
-          :info,
-          trans("%{name} complete", inter: [name: name])
-        )
+          :error ->
+            LiveAdmin.PubSub.announce(
+              session.id,
+              :error,
+              trans("%{name} encountered an error and stopped", inter: [name: name])
+            )
+        end
       end)
 
     LiveAdmin.PubSub.update_job(session.id, job.pid, progress: 0, label: to_string(name))


### PR DESCRIPTION
## Summary

Two related issues in the bulk action handler on the index page (`LiveAdmin.Components.Container.Index`):

### 1. Progress bar oscillation

The `handle_event("action", ...)` handler wraps each selected record's processing in `try/rescue/after`, with the `after` clause broadcasting `progress: 1` for the job pid. Because that block sits inside the `Enum.each` loop over `socket.assigns.selected`, `progress: 1` is broadcast after every record — not once when the batch completes.

The nav jobs LiveView (`LiveAdmin.Components.Nav.Jobs`) treats any `progress >= 1` message as completion: it snaps the bar to 100% and schedules a `:remove_job` 1500 ms later. Before that fires, the next iteration broadcasts a partial `idx / count`, which the handler matches by pid and resets the bar back down. Visually that's a progress bar oscillating between full and partial across the duration of the bulk action.

Additionally, the body used `Enum.with_index/1` (zero-based), so per-iteration progress was `0/n .. (n-1)/n` — the bar could never reach 100% from the body, only from the spurious `after`.

### 2. Inaccurate error message

The per-record `rescue` announces `"%{name} encountered an error and stopped"` — but the surrounding `Enum.each` does not stop. The loop continues processing subsequent records after an error, contradicting the message and (more importantly) running an action that has already proven unsafe for the current batch.

## Fix

- Drop the `after` clause entirely. With `Enum.with_index(1)` and dividing by a hoisted `total`, per-iteration progress climbs `1/n .. n/n` and reaches 100% naturally on the last record. If the loop halts or the task crashes, the nav jobs LiveView already monitors the task pid and cleans up the entry on `:DOWN`.
- Switch `Enum.each` to `Enum.reduce_while`, halting with `:error` when a record raises. The final announcement (`complete` vs `encountered an error and stopped`) is chosen based on the reduce result.

## Test plan

- [x] `mix format --check-formatted` passes
- [x] `mix credo` passes
- [x] `mix test test/live_admin/components/container_test.exs` — 30/30 pass
- [ ] Manually verify: selecting multiple records and running an action shows a smoothly progressing bar (no flashing between full and partial)
- [ ] Manually verify: when a record's action raises, the loop halts and remaining records are not processed