### PR TITLE
fix: reject contradictory create/update config

### DIFF
--- a/lib/live_admin/router.ex
+++ b/lib/live_admin/router.ex
@@ -22,6 +22,7 @@ defmodule LiveAdmin.Router do
         |> Map.fetch!(:path)
 
       @base_path Path.join(["/", current_path, unquote(path)])
+      @__live_admin_scope_opts__ unquote(opts)
 
       scope unquote(path), alias: false, as: false do
         live_session :"live_admin_#{@base_path}",
@@ -54,6 +55,14 @@ defmodule LiveAdmin.Router do
     import Phoenix.LiveView.Router, only: [live: 4]
 
     quote bind_quoted: [path: path, resource_mod: resource_mod] do
+      LiveAdmin.Router.__validate_config__!(
+        resource_mod,
+        @__live_admin_scope_opts__,
+        create_with: Application.compile_env(:live_admin, :create_with),
+        update_with: Application.compile_env(:live_admin, :update_with),
+        components: Application.compile_env(:live_admin, :components, [])
+      )
+
       full_path = Path.join(@base_path, path)
 
       live(path, LiveAdmin.Components.Container, :index,
@@ -76,6 +85,31 @@ defmodule LiveAdmin.Router do
         metadata: %{base_path: @base_path, resource: {path, resource_mod}}
       )
     end
+  end
+
+  @disabled_with_custom_component [
+    {:create_with, :create},
+    {:update_with, :edit}
+  ]
+
+  @doc false
+  def __validate_config__!(resource_mod, scope_opts, app_opts) do
+    Code.ensure_compiled!(resource_mod)
+    resource_opts = resource_mod.__live_admin_config__()
+    levels = [resource_opts, scope_opts, app_opts]
+
+    Enum.each(@disabled_with_custom_component, fn {with_key, component_key} ->
+      disabled? = Enum.any?(levels, &(Keyword.get(&1, with_key) == false))
+
+      component_set? =
+        Enum.any?(levels, &Keyword.has_key?(Keyword.get(&1, :components, []), component_key))
+
+      if disabled? and component_set? do
+        raise ArgumentError,
+              "invalid config for resource #{inspect(resource_mod)}: " <>
+                "#{with_key}: false cannot be combined with a custom :#{component_key} component"
+      end
+    end)
   end
 
   def build_session(conn, base_path, opts) do

--- a/test/live_admin/router_test.exs
+++ b/test/live_admin/router_test.exs
@@ -1,0 +1,39 @@
+defmodule LiveAdmin.RouterTest do
+  use ExUnit.Case, async: true
+
+  alias LiveAdmin.Router
+
+  describe "create_with: false at resource level with custom :create component at resource level" do
+    test "raises ArgumentError" do
+      assert_raise ArgumentError, ~r/create_with: false.*:create component/, fn ->
+        Router.__validate_config__!(LiveAdminTest.UserWithCustomCreate, [], [])
+      end
+    end
+  end
+
+  describe "create_with: false at scope level with custom :create component at resource level" do
+    test "raises ArgumentError" do
+      assert_raise ArgumentError, ~r/create_with: false.*:create component/, fn ->
+        Router.__validate_config__!(
+          LiveAdminTest.UserWithCustomCreateOnly,
+          [create_with: false],
+          []
+        )
+      end
+    end
+  end
+
+  describe "update_with: false at app level with custom :edit component at resource level" do
+    test "raises ArgumentError" do
+      assert_raise ArgumentError, ~r/update_with: false.*:edit component/, fn ->
+        Router.__validate_config__!(LiveAdminTest.UserWithCustomEditOnly, [], update_with: false)
+      end
+    end
+  end
+
+  describe "resource without conflicting config" do
+    test "returns :ok" do
+      assert :ok == Router.__validate_config__!(LiveAdminTest.User, [], [])
+    end
+  end
+end

--- a/test/support/resources.ex
+++ b/test/support/resources.ex
@@ -1,3 +1,28 @@
+defmodule LiveAdminTest.CustomFormComponent do
+  use Phoenix.LiveComponent
+
+  def render(assigns), do: ~H"<div>custom form</div>"
+end
+
+defmodule LiveAdminTest.UserWithCustomCreate do
+  use LiveAdmin.Resource,
+    schema: LiveAdminTest.User,
+    create_with: false,
+    components: [create: LiveAdminTest.CustomFormComponent]
+end
+
+defmodule LiveAdminTest.UserWithCustomCreateOnly do
+  use LiveAdmin.Resource,
+    schema: LiveAdminTest.User,
+    components: [create: LiveAdminTest.CustomFormComponent]
+end
+
+defmodule LiveAdminTest.UserWithCustomEditOnly do
+  use LiveAdmin.Resource,
+    schema: LiveAdminTest.User,
+    components: [edit: LiveAdminTest.CustomFormComponent]
+end
+
 defmodule LiveAdminTest.User do
   use Ecto.Schema
 


### PR DESCRIPTION
## Summary

Validates at compile time, in `admin_resource/2`, that a resource isn't configured with `create_with: false` alongside a custom `:create` component (or `update_with: false` alongside a custom `:edit` component). These combinations are contradictory: the disabling option says the action is off, while the component override says it's customized.

Catching this at compile time forces users to pick one approach rather than the silent / unexpected runtime behavior reported in #139.

Implementation notes:
- `live_admin/3` stashes scope opts in `@__live_admin_scope_opts__` on the router module.
- `admin_resource/2` calls `LiveAdmin.Router.__validate_config__!/3` at compile time with the resource module, scope opts, and the app-level config read via `Application.compile_env`.
- App-level `:create_with`, `:update_with`, and `:components` are now read via `compile_env` rather than `get_env`. They can no longer be changed at runtime without recompiling.

Closes #139

## Test plan

- [x] `docker compose run app mix test` — 39 tests pass
- [x] `docker compose run app mix credo` on changed files — clean
- [x] New `test/live_admin/router_test.exs` covers: resource-level conflict, scope-level conflict, app-level conflict, and a no-conflict baseline