### PR TITLE
fix: accept MFA tuple in css_overrides config schema

### DIFF
--- a/lib/application.ex
+++ b/lib/application.ex
@@ -7,7 +7,7 @@ defmodule LiveAdmin.Application do
     global_options_schema =
       LiveAdmin.base_configs_schema() ++
         [
-          css_overrides: [type: :string],
+          css_overrides: [type: {:or, [:string, {:tuple, [:atom, :atom, {:list, :any}]}]}],
           gettext_backend: [type: :atom],
           session_store: [type: :atom]
         ]


### PR DESCRIPTION
## Summary

The `:css_overrides` schema in `LiveAdmin.Application` validated `type: :string`, so the app crashed at boot when a caller supplied the `{m, f, []}` form — even though `LiveAdmin.View.render_css/1` already pattern-matched on that form.

Widens the schema to `{:or, [:string, {:tuple, [:atom, :atom, {:list, :any}]}]}` so the schema matches the runtime.

Closes #140

## Test plan

- [x] `docker compose run app mix test` — 35 tests pass