### PR TITLE
fix: only flag same-level create/update conflicts

### DIFF
--- a/lib/live_admin/router.ex
+++ b/lib/live_admin/router.ex
@@ -98,17 +98,17 @@ defmodule LiveAdmin.Router do
     resource_opts = resource_mod.__live_admin_config__()
     levels = [resource_opts, scope_opts, app_opts]
 
-    Enum.each(@disabled_with_custom_component, fn {with_key, component_key} ->
-      disabled? = Enum.any?(levels, &(Keyword.get(&1, with_key) == false))
+    Enum.each(levels, fn level ->
+      Enum.each(@disabled_with_custom_component, fn {with_key, component_key} ->
+        disabled? = Keyword.get(level, with_key) == false
+        component_set? = Keyword.has_key?(Keyword.get(level, :components, []), component_key)
 
-      component_set? =
-        Enum.any?(levels, &Keyword.has_key?(Keyword.get(&1, :components, []), component_key))
-
-      if disabled? and component_set? do
-        raise ArgumentError,
-              "invalid config for resource #{inspect(resource_mod)}: " <>
-                "#{with_key}: false cannot be combined with a custom :#{component_key} component"
-      end
+        if disabled? and component_set? do
+          raise ArgumentError,
+                "invalid config for resource #{inspect(resource_mod)}: " <>
+                  "#{with_key}: false cannot be combined with a custom :#{component_key} component at the same level"
+        end
+      end)
     end)
   end
 

--- a/test/live_admin/router_test.exs
+++ b/test/live_admin/router_test.exs
@@ -3,7 +3,7 @@ defmodule LiveAdmin.RouterTest do
 
   alias LiveAdmin.Router
 
-  describe "create_with: false at resource level with custom :create component at resource level" do
+  describe "create_with: false and custom :create component at the resource level" do
     test "raises ArgumentError" do
       assert_raise ArgumentError, ~r/create_with: false.*:create component/, fn ->
         Router.__validate_config__!(LiveAdminTest.UserWithCustomCreate, [], [])
@@ -11,23 +11,48 @@ defmodule LiveAdmin.RouterTest do
     end
   end
 
-  describe "create_with: false at scope level with custom :create component at resource level" do
+  describe "create_with: false and custom :create component at the scope level" do
     test "raises ArgumentError" do
       assert_raise ArgumentError, ~r/create_with: false.*:create component/, fn ->
         Router.__validate_config__!(
-          LiveAdminTest.UserWithCustomCreateOnly,
-          [create_with: false],
+          LiveAdminTest.User,
+          [create_with: false, components: [create: LiveAdminTest.CustomFormComponent]],
           []
         )
       end
     end
   end
 
-  describe "update_with: false at app level with custom :edit component at resource level" do
+  describe "update_with: false and custom :edit component at the app level" do
     test "raises ArgumentError" do
       assert_raise ArgumentError, ~r/update_with: false.*:edit component/, fn ->
-        Router.__validate_config__!(LiveAdminTest.UserWithCustomEditOnly, [], update_with: false)
+        Router.__validate_config__!(
+          LiveAdminTest.User,
+          [],
+          update_with: false,
+          components: [edit: LiveAdminTest.CustomFormComponent]
+        )
       end
+    end
+  end
+
+  describe "create_with: false at scope level with custom :create component at resource level" do
+    test "returns :ok" do
+      assert :ok ==
+               Router.__validate_config__!(
+                 LiveAdminTest.UserWithCustomCreateOnly,
+                 [create_with: false],
+                 []
+               )
+    end
+  end
+
+  describe "update_with: false at app level with custom :edit component at resource level" do
+    test "returns :ok" do
+      assert :ok ==
+               Router.__validate_config__!(LiveAdminTest.UserWithCustomEditOnly, [],
+                 update_with: false
+               )
     end
   end
 


### PR DESCRIPTION
## Summary

The validation added in #144 rejected any configuration where `create_with: false` (or `update_with: false`) appeared at one config level while a custom `:create` (or `:edit`) component appeared at another. That's incompatible with the documented use case from #139: disable create globally, then re-enable it per-resource via a custom component.

## Change

Walk each config level independently. Only raise when a single level contains both the disabling option and the custom component. Cross-level overrides resolve via normal precedence (resource > scope > app), with the more-specific level winning.

## Tests

- Kept the existing same-level (resource) test
- Added same-level tests at scope and app levels
- Flipped the two cross-level tests from "raises" to "returns :ok"