### PR TITLE
fix: return nil from Resource.find on uncastable id

### DIFF
--- a/lib/live_admin/resource.ex
+++ b/lib/live_admin/resource.ex
@@ -55,6 +55,8 @@ defmodule LiveAdmin.Resource do
     resource
     |> query(nil, config)
     |> repo.get(key, prefix: prefix)
+  rescue
+    Ecto.Query.CastError -> nil
   end
 
   def delete(record, resource, session, repo, config) do

--- a/test/live_admin/components/container_test.exs
+++ b/test/live_admin/components/container_test.exs
@@ -219,6 +219,18 @@ defmodule LiveAdmin.Components.ContainerTest do
     end
   end
 
+  describe "edit resource with id that cannot be cast" do
+    setup %{conn: conn} do
+      {:ok, view, _} = live(conn, "/user/edit/not-a-number")
+
+      %{view: view}
+    end
+
+    test "renders no record found message", %{view: view} do
+      assert has_element?(view, "*", "No record found")
+    end
+  end
+
   describe "edit resource with embed" do
     setup %{conn: conn} do
       user = Repo.insert!(%User{settings: %{}})


### PR DESCRIPTION
## Summary

Visiting a show/edit URL with an id that can't be cast to the schema's primary key type (e.g. `/foo/show/null` or `/foo/edit/abc` when the pk is an integer) raised `Ecto.Query.CastError` inside `LiveAdmin.Components.Container.handle_params/3` during connected mount, which LiveView reports to the client as a 400.

Rescue the cast error in `Resource.find/5` and return `nil` — the existing `record: nil` branch in `Components.Container.Form.render/1` already renders a "No record found" message, so callers see a graceful result instead of a crash.

## Test plan

- [x] New test exercising `/user/edit/not-a-number` asserts the "No record found" message renders
- [x] `mix test test/live_admin/components/container_test.exs` — 31 tests, 0 failures