### PR TITLE
Fix deprecated map.field call on Elixir 1.19

### DIFF
--- a/lib/live_admin.ex
+++ b/lib/live_admin.ex
@@ -207,7 +207,7 @@ defmodule LiveAdmin do
            schema |> parent_associations() |> Enum.find(&(&1.owner_key == field_name)),
          config when not is_nil(config) <-
            Enum.find(resources, fn {_, resource} ->
-             Keyword.fetch!(resource.__live_admin_config__, :schema) == assoc_schema
+             Keyword.fetch!(resource.__live_admin_config__(), :schema) == assoc_schema
            end) do
       case part do
         nil -> config


### PR DESCRIPTION
## What

Adds parentheses to the `__live_admin_config__` call in `LiveAdmin.associated_resource/4`.

## Why

Invoking the generated `__live_admin_config__/0` via `map.field` notation (`resource.__live_admin_config__`) is deprecated as of Elixir 1.19 and emits a warning at runtime; it will break in a future release. Making it an explicit function call (`resource.__live_admin_config__()`) resolves the deprecation.

## Verification

- `mix do compile --warnings-as-errors + test` — clean compile, 45 tests, 0 failures; the deprecation warning no longer appears in test output

🤖 Generated with [Claude Code](https://claude.com/claude-code)