### PR TITLE
Bump version to 1.0.0-rc.4

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule LiveAdmin.MixProject do
   use Mix.Project
 
-  @version "1.0.0-rc.3"
+  @version "1.0.0-rc.4"
 
   def project do
     [


### PR DESCRIPTION
Bumps `@version` to `1.0.0-rc.4` for the next release candidate.

Includes since rc.3:
- #149 — drop redundant compile-time config validator
- #150 — fix deprecated `map.field` call on Elixir 1.19

🤖 Generated with [Claude Code](https://claude.com/claude-code)