### PR TITLE
fix: normalize invalid pagination params in the url

### DIFF
--- a/lib/live_admin/components/container.ex
+++ b/lib/live_admin/components/container.ex
@@ -263,14 +263,21 @@ defmodule LiveAdmin.Components.Container do
     params =
       {defaults, types}
       |> Ecto.Changeset.cast(params, Map.keys(types))
-      |> Ecto.Changeset.apply_action!(:update)
+      |> Ecto.Changeset.apply_changes()
 
     assign(socket, params)
   end
 
   defp redirect_with_params(socket, params) do
-    if Enum.all?(["per", "page", "sort-attr", "sort-dir"], &Map.has_key?(params, &1)) &&
-         Map.get(params, "prefix") == socket.assigns.prefix do
+    canonical = %{
+      "page" => to_string(socket.assigns.page),
+      "per" => to_string(socket.assigns.per),
+      "sort-attr" => to_string(socket.assigns.sort_attr),
+      "sort-dir" => to_string(socket.assigns.sort_dir),
+      "prefix" => socket.assigns.prefix
+    }
+
+    if Enum.all?(canonical, fn {key, val} -> Map.get(params, key) == val end) do
       socket
     else
       push_navigate(socket,

--- a/test/live_admin/components/container_test.exs
+++ b/test/live_admin/components/container_test.exs
@@ -100,6 +100,23 @@ defmodule LiveAdmin.Components.ContainerTest do
     end
   end
 
+  describe "list resource with invalid page param" do
+    setup %{conn: conn} do
+      Repo.insert!(%User{})
+
+      {:error, {:live_redirect, %{to: redirect_to}}} =
+        live(conn, "/user?prefix=public&per=10&page=abc&sort-attr=id&sort-dir=asc")
+
+      %{redirect_to: redirect_to}
+    end
+
+    test "redirects to url with the invalid param replaced by the default", %{
+      redirect_to: redirect_to
+    } do
+      assert redirect_to =~ ~r/page=1(?![0-9])/
+    end
+  end
+
   describe "list resource with search param not matching any records" do
     setup %{conn: conn} do
       Repo.insert!(%User{name: "Tom"})


### PR DESCRIPTION
An invalid `page`/`per`/`sort` query param (e.g. a hand-edited or mangled URL like `?page=110\5`) raised `Ecto.InvalidChangesetError`, 500ing the entire resource view.

`assign_pagination_params` bang-applied the pagination changeset, so any value that failed to cast crashed the view. Two changes:

- Cast with `apply_changes/1` instead of `apply_action!/2`, so an invalid param falls back to its default while valid params still apply.
- Compare the URL's raw params against the canonicalized assigns in `redirect_with_params`, so an invalid (or non-canonical) value triggers the existing redirect. The bad value is transparently replaced in the address bar (e.g. `page=abc` → `page=1`) rather than left mismatched against what's rendered.

The redirect terminates because `route_with_params` emits the same param keys the comparison expects, so the canonicalized URL matches on the next pass.

Added a container test that navigates with an invalid `page` param and asserts the LiveView redirects to a URL carrying the default `page=1`.
